### PR TITLE
Zip File support and ability to exclude fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 
 .vscode
 .venv
+.idea

--- a/README.md
+++ b/README.md
@@ -55,15 +55,14 @@ Here is an example of basic config, and a bit of a run down on each of the prope
         }]
     }
     ```
-
+- **aws_access_key_id**: AWS access key ID
+- **aws_secret_access_key**: AWS secret access key
+- **aws_endpoint_url**: (Optional): The complete URL to use for the constructed client. Normally, botocore will automatically construct the appropriate URL to use when communicating with a service. You can specify a complete URL (including the "http/https" scheme) to override this behavior. For example https://nyc3.digitaloceanspaces.com
 - **start_date**: This is the datetime that the tap will use to look for newly updated or created files, based on the modified timestamp of the file.
-- **account_id**: This is your AWS account id
-- **role_name**: In order to access a bucket, the tap uses boto3 to assume a role in your AWS account. If you have your AWS account credentials set up locally, you can specify this as a role which your local user has access to assume, and boto3 should by default pick up your AWS keys from the local environment.
 - **bucket**: The name of the bucket to search for files under.
-- **external_id**: (potentially optional) Running this locally, you should be able to omit this property, it is provided to allow the tap to access buckets in accounts where the user doesn't have access to the account itself, but is able to assume a role in that account, through a shared secret. This is that secret, in that case.
-- **tables**: An escaped JSON string that the tap will use to search for files, and emit records as "tables" from those files. Will be used by a [`voluptuous`](https://github.com/alecthomas/voluptuous)-based configuration checker.
+- **tables**: JSON object that the tap will use to search for files, and emit records as "tables" from those files. 
 
-The `table` field consists of one or more objects, JSON encoded as an array and escaped using backslashes (e.g., `\"` for `"` and `\\` for `\`), that describe how to find files and emit records. A more detailed (and unescaped) example below:
+The `table` field consists of one or more objects, that describe how to find files and emit records. A more detailed (and unescaped) example below:
 
 ```
 [
@@ -71,8 +70,8 @@ The `table` field consists of one or more objects, JSON encoded as an array and 
         "search_prefix": "exports"
         "search_pattern": "my_table\\/.*\\.csv",
         "table_name": "my_table",
-        "key_properties": "id",
-        "date_overrides": "created_at",
+        "key_properties": ["id"],
+        "date_overrides": ["created_at"],
         "delimiter": ","
     },
     ...

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The `table` field consists of one or more objects, that describe how to find fil
         "search_pattern": "my_table\\/.*\\.csv",
         "table_name": "my_table",
         "key_properties": ["id"],
+        "exclude_properties": ["user:name"],
         "date_overrides": ["created_at"],
         "delimiter": ","
     },
@@ -82,6 +83,7 @@ The `table` field consists of one or more objects, that describe how to find fil
 - **search_pattern**: This is an escaped regular expression that the tap will use to find files in the bucket + prefix. It's a bit strange, since this is an escaped string inside of an escaped string, any backslashes in the RegEx will need to be double-escaped.
 - **table_name**: This value is a string of your choosing, and will be used to name the stream that records are emitted under for files matching content.
 - **key_properties**: These are the "primary keys" of the CSV files, to be used by the target for deduplication and primary key definitions downstream in the destination.
+- **exclude_properties**: Specifies fields to be excluded from the import.
 - **date_overrides**: Specifies field names in the files that are supposed to be parsed as a datetime. The tap doesn't attempt to automatically determine if a field is a datetime, so this will make it explicit in the discovered schema.
 - **delimiter**: This allows you to specify a custom delimiter, such as `\t` or `|`, if that applies to your files.
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,8 +1,13 @@
 {
-    "start_date": "2017-11-02T00:00:00Z",
-    "account_id": "1234567890",
-    "role_name": "role_with_bucket_access",
-    "bucket": "my-bucket",
-    "external_id": "my_optional_secret_external_id",
-    "tables": "[{\"search_prefix\":\"exports\",\"search_pattern\":\"my_table\\\\/.*\\\\.csv\",\"table_name\":\"my_table\",\"key_properties\":\"id\",\"date_overrides\":\"created_at\",\"delimiter\":\",\"}]",
+    "aws_access_key_id": "ACCESS_KEY",
+    "aws_secret_access_key": "SECRET_ACCESS_KEY",
+    "start_date": "2000-01-01T00:00:00Z",
+    "bucket": "tradesignals-crawler",
+    "tables": [{
+        "search_prefix": "feeds",
+        "search_pattern": ".csv",
+        "table_name": "my_table",
+        "key_properties": ["id"],
+        "delimiter": ","
+    }]
 }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='pipelinewise-tap-s3-csv',
-      version='1.0.3',
+      version='1.0.4',
       description='Singer.io tap for extracting CSV files from S3 - PipelineWise compatible',
       author='TransferWise',
       url='https://github.com/transferwise/pipelinewise-tap-s3-csv',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='pipelinewise-tap-s3-csv',
-      version='1.0.4',
+      version='1.0.5',
       description='Singer.io tap for extracting CSV files from S3 - PipelineWise compatible',
       author='TransferWise',
       url='https://github.com/transferwise/pipelinewise-tap-s3-csv',

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,14 @@
 
 from setuptools import setup
 
+with open('README.md') as f:
+      long_description = f.read()
+
 setup(name='pipelinewise-tap-s3-csv',
       version='1.0.5',
       description='Singer.io tap for extracting CSV files from S3 - PipelineWise compatible',
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       author='TransferWise',
       url='https://github.com/transferwise/pipelinewise-tap-s3-csv',
       classifiers=[

--- a/tap_s3_csv/discover.py
+++ b/tap_s3_csv/discover.py
@@ -19,7 +19,7 @@ def discover_streams(config: Dict)-> List[Dict]:
 
     for table_spec in config['tables']:
         schema = discover_schema(config, table_spec)
-        
+
         # exclude fields according to configuration
         fields_to_exclude = table_spec.get('exclude_properties', [])
         for field_name in fields_to_exclude:
@@ -27,7 +27,7 @@ def discover_streams(config: Dict)-> List[Dict]:
                 del schema['properties'][field_name]
             else:
                 LOGGER.info('%s field not found in schema', field_name)
-            
+
         streams.append({'stream': table_spec['table_name'],
                         'tap_stream_id': table_spec['table_name'],
                         'schema': schema,

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -122,7 +122,7 @@ def sample_file(config, table_spec, s3_path, sample_rate):
     :return: generator containing the samples as dictionaries
     """
     file_stream = get_file_stream(config, s3_path)
-    
+
     iterator = get_row_iterator(file_stream, table_spec) #pylint:disable=protected-access
 
     current_row = 0
@@ -294,7 +294,14 @@ def get_file_handle(config: Dict, s3_path: str) -> Iterator:
     s3_object = s3_bucket.Object(s3_path)
     return s3_object.get()['Body']
 
-def get_file_stream(config, s3_path):
+def get_file_stream(config: Dict, s3_path: str) -> Iterator:
+    """
+    Get file stream to the file located in the s3 path.
+    It automatically decompress the file if it is zipped.
+    :param config: tap config
+    :param s3_path: file path in S3
+    :return: file stream
+    """
     file_handle = get_file_handle(config, s3_path)
     # if csv is zipped, unzip it
     stream = None
@@ -305,7 +312,12 @@ def get_file_stream(config, s3_path):
         stream = file_handle._raw_stream
     return stream
 
-def stream_zip_decompress(stream):
+def stream_zip_decompress(stream: Iterator) -> Iterator:
+    """
+    Decompress first file of a zipped file stream
+    :param stream: file stream
+    :return: uncompressed file stream
+    """
     buffer = io.BytesIO(stream.read())
-    z = zipfile.ZipFile(buffer)
-    return z.open(z.infolist()[0])
+    file = zipfile.ZipFile(buffer)
+    return file.open(file.infolist()[0])

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -99,6 +99,7 @@ def merge_dicts(first, second):
 
 def sample_file(config, table_spec, s3_path, sample_rate):
     file_handle = get_file_handle(config, s3_path)
+    # _raw_stream seems like the wrong way to access this..
     iterator = csv.get_row_iterator(file_handle._raw_stream, table_spec) #pylint:disable=protected-access
 
     current_row = 0
@@ -156,7 +157,7 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
     matched_files_count = 0
     unmatched_files_count = 0
     max_files_before_log = 30000
-    for s3_object in list_files_in_bucket(bucket, prefix):
+    for s3_object in list_files_in_bucket(bucket, prefix, aws_endpoint_url=config.get('aws_endpoint_url')):
         key = s3_object['Key']
         last_modified = s3_object['LastModified']
 
@@ -194,8 +195,14 @@ def get_input_files_for_table(config, table_spec, modified_since=None):
 
 
 @retry_pattern()
-def list_files_in_bucket(bucket, search_prefix=None):
-    s3_client = boto3.client('s3')
+def list_files_in_bucket(bucket, search_prefix=None, aws_endpoint_url=None):
+
+
+    # override default endpoint for non aws s3 services
+    if aws_endpoint_url is not None:
+        s3_client = boto3.client('s3', endpoint_url=f"https://{aws_endpoint_url}")
+    else:
+        s3_client = boto3.client('s3')
 
     s3_object_count = 0
 
@@ -225,7 +232,14 @@ def list_files_in_bucket(bucket, search_prefix=None):
 @retry_pattern()
 def get_file_handle(config, s3_path):
     bucket = config['bucket']
-    s3_client = boto3.resource('s3')
+    aws_endpoint_url = config.get('aws_endpoint_url')
+
+    # override default endpoint for non aws s3 services
+    if aws_endpoint_url is not None:
+        s3_client = boto3.resource('s3', endpoint_url=f"https://{aws_endpoint_url}")
+    else:
+        s3_client = boto3.resource('s3')
+
 
     s3_bucket = s3_client.Bucket(bucket)
     s3_object = s3_bucket.Object(s3_path)


### PR DESCRIPTION
We are using this tap for importing all the AWS billing information into our Data Warehouse. We ran into two issues:
* some csv files are zipped
* some fields had identical names, just different casing but Snowflake didn't like that so we needed to exclude one of them from the import.

This PR addresses both issues and should enable others to benefit from those as well.