### PR TITLE
Logger Bug Fix and Accept Tables Config as Serialized Json

### DIFF
--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -14,7 +14,7 @@ from tap_s3_csv import s3
 from tap_s3_csv.sync import sync_stream
 from tap_s3_csv.config import CONFIG_CONTRACT
 
-LOGGER = get_logger()
+LOGGER = get_logger(name='tap_s3_csv')
 
 REQUIRED_CONFIG_KEYS = ["start_date", "bucket"]
 

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -5,6 +5,7 @@ Tap S3 csv main script
 import sys
 import ujson
 import singer
+import json
 
 from typing import Dict
 from singer import metadata, get_logger
@@ -13,7 +14,7 @@ from tap_s3_csv import s3
 from tap_s3_csv.sync import sync_stream
 from tap_s3_csv.config import CONFIG_CONTRACT
 
-LOGGER = get_logger('tap_s3_csv')
+LOGGER = get_logger()
 
 REQUIRED_CONFIG_KEYS = ["start_date", "bucket"]
 
@@ -81,8 +82,11 @@ def main() -> None:
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
 
-    # Reassign the config tables to the validated object
-    config['tables'] = CONFIG_CONTRACT(config.get('tables', {}))
+    # Reassign the config tables to the validated object, accept encoded json
+    tables = config.get('tables', {})
+    if isinstance(tables, str):
+        tables = json.loads(tables)
+    config['tables'] = CONFIG_CONTRACT(tables)
 
     try:
         for _ in s3.list_files_in_bucket(config['bucket']):

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -14,7 +14,7 @@ from tap_s3_csv import s3
 from tap_s3_csv.sync import sync_stream
 from tap_s3_csv.config import CONFIG_CONTRACT
 
-LOGGER = get_logger(name='tap_s3_csv')
+LOGGER = get_logger()
 
 REQUIRED_CONFIG_KEYS = ["start_date", "bucket"]
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -16,7 +16,7 @@ from singer import get_logger
 
 from tap_s3_csv import conversion
 
-LOGGER = get_logger('tap_s3_csv')
+LOGGER = get_logger(name='tap_s3_csv')
 
 SDC_SOURCE_BUCKET_COLUMN = "_sdc_source_bucket"
 SDC_SOURCE_FILE_COLUMN = "_sdc_source_file"

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -16,7 +16,7 @@ from singer import get_logger
 
 from tap_s3_csv import conversion
 
-LOGGER = get_logger(name='tap_s3_csv')
+LOGGER = get_logger()
 
 SDC_SOURCE_BUCKET_COLUMN = "_sdc_source_bucket"
 SDC_SOURCE_FILE_COLUMN = "_sdc_source_file"

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -11,7 +11,7 @@ from singer_encodings.csv import get_row_iterator # pylint:disable=no-name-in-mo
 
 from tap_s3_csv import s3
 
-LOGGER = get_logger('tap_s3_csv')
+LOGGER = get_logger(name='tap_s3_csv')
 
 
 def sync_stream(config: Dict, state: Dict, table_spec: Dict, stream: Dict) -> int:

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -11,7 +11,7 @@ from singer_encodings.csv import get_row_iterator # pylint:disable=no-name-in-mo
 
 from tap_s3_csv import s3
 
-LOGGER = get_logger(name='tap_s3_csv')
+LOGGER = get_logger()
 
 
 def sync_stream(config: Dict, state: Dict, table_spec: Dict, stream: Dict) -> int:


### PR DESCRIPTION
## Problem

A common pattern is to store config entries as environment variables which get written to a config.json at runtime. In this case the `tables` key would have to be serialized json. The tap currently assumes its a dict without checking, so an error is thrown when iterating the tables key for the stream details.

## Proposed changes

Accept serialized json for the `tables` config key by checking if its a string and loading it before using it.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions