### PR TITLE
Adding support to override fields as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The `table` field consists of one or more objects, that describe how to find fil
         "table_name": "my_table",
         "key_properties": ["id"],
         "date_overrides": ["created_at"],
+        "string_overrides": ["my_token"],        
         "delimiter": ","
     },
     ...
@@ -94,7 +95,8 @@ The `table` field consists of one or more objects, that describe how to find fil
 - **search_pattern**: This is an escaped regular expression that the tap will use to find files in the bucket + prefix. It's a bit strange, since this is an escaped string inside of an escaped string, any backslashes in the RegEx will need to be double-escaped.
 - **table_name**: This value is a string of your choosing, and will be used to name the stream that records are emitted under for files matching content.
 - **key_properties**: These are the "primary keys" of the CSV files, to be used by the target for deduplication and primary key definitions downstream in the destination.
-- **date_overrides**: Specifies field names in the files that are supposed to be parsed as a datetime. The tap doesn't attempt to automatically determine if a field is a datetime, so this will make it explicit in the discovered schema.
+- **date_overrides**: Optional: Specifies field names in the files that are supposed to be parsed as a datetime. The tap doesn't attempt to automatically determine if a field is a datetime, so this will make it explicit in the discovered schema.
+- **string_overrides**: Optional: Specifies field names in the files that are supposed to be parsed as a string. The tap attempts to automatically determine the datatype of a field e.g integer, this override any discovery and will set the field to be a string in the discovered schema.
 - **delimiter**: This allows you to specify a custom delimiter, such as `\t` or `|`, if that applies to your files.
 
 A sample configuration is available inside [config.sample.json](config.sample.json)

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -9,5 +9,6 @@ CONFIG_CONTRACT = Schema([{
     Optional('key_properties'): [str],
     Optional('search_prefix'): str,
     Optional('date_overrides'): [str],
+    Optional('string_overrides'): [str],
     Optional('delimiter'): str
 }])

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -32,8 +32,12 @@ def generate_schema(samples: List[Dict], table_spec: Dict) -> Dict:
 
         date_overrides = set(table_spec.get('date_overrides', []))
 
+        string_overrides = set(table_spec.get('string_overrides', []))
+
         if header in date_overrides:
             schema[header] = {'type': ['null', 'string'], 'format': 'date-time'}
+        elif header in string_overrides:
+            schema[header] = {'type': ['null', 'string']}
         else:
             if isinstance(header_type, IntegerType):
                 schema[header] = {

--- a/tests/unit/test_conversion.py
+++ b/tests/unit/test_conversion.py
@@ -36,6 +36,43 @@ class TestConversion(unittest.TestCase):
             'sold_at': {'type': ['null', 'string']}
         }, schema)
 
+class TestStringConversion(unittest.TestCase):
+    def test_generate_schema(self):
+        samples = [
+            dict(id='1', name='productA', added_at='2017/05/18 10:40:22', price='22.99', sold='true',
+                 sold_at='2019-11-29'),
+            dict(id='4', name='productB', added_at='2017/05/18 10:40:22', price='18', sold='false'),
+            dict(id='6', name='productC', added_at='2017/05/18 10:40:22', price='14.6', sold='true',
+                 sold_at='2019-12-11'),
+        ]
+
+        table_specs = {
+            'string_overrides': ['id','added_at','price']
+        }
+
+        schema = generate_schema(samples, table_specs)
+
+        self.assertDictEqual({
+            'id': {
+                'type': ['null', 'string']
+            },
+            'name': {
+                'type': ['null', 'string']
+            },
+            'added_at': {
+                'type': ['null', 'string']
+            },
+            'price': {
+                'type': ['null', 'string']
+            },
+            'sold': {
+                'type': ['null', 'string']
+            },
+            'sold_at': {
+                'type': ['null', 'string']
+            }
+        }, schema)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

There are sometimes cases where the discovered schema incorrectly assumes a field is a integer or may include data quality issues.

## Proposed changes

Provide the user of tap-s3-csv the option to override a list of fields to be strings. This may be useful where a csv file sometimes includes a data quality error and you still want it to be loaded or where the scanning of the csv file incorrectly assumes a field is a integer.


## Types of changes

This code introduces an optional feature of including a list of fields to override in the json array parameter string_overrides. It does not change current behaviour if the feature is not used. This feature works in the same manner as the date_overrides.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions