### PR TITLE
feat: add encoding property in table structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ The `table` field consists of one or more objects, that describe how to find fil
         "table_name": "my_table",
         "key_properties": ["id"],
         "date_overrides": ["created_at"],
-        "delimiter": ","
+        "delimiter": ",",
+        "encoding": "iso-8859-1"
     },
     ...
 ]

--- a/config.sample.json
+++ b/config.sample.json
@@ -8,6 +8,7 @@
         "search_pattern": ".csv",
         "table_name": "my_table",
         "key_properties": ["id"],
-        "delimiter": ","
+        "delimiter": ",",
+        "encoding": "iso-8859-1"
     }]
 }

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -9,5 +9,6 @@ CONFIG_CONTRACT = Schema([{
     Optional('key_properties'): [str],
     Optional('search_prefix'): str,
     Optional('date_overrides'): [str],
-    Optional('delimiter'): str
+    Optional('delimiter'): str,
+    Optional('encoding'): str
 }])

--- a/tap_s3_csv/row_iterator.py
+++ b/tap_s3_csv/row_iterator.py
@@ -1,0 +1,28 @@
+import codecs
+import csv
+from singer_encodings import compression
+from singer_encodings.csv import SDC_EXTRA_COLUMN  # pylint:disable=no-name-in-module
+
+def get_row_iterator(iterable, options=None):
+    """Accepts an interable, options and returns a csv.DictReader object
+    which can be used to yield CSV rows."""
+    options = options or {}
+
+    file_stream = codecs.iterdecode(iterable, encoding=options.get('encoding', 'utf-8'))
+
+    # Replace any NULL bytes in the line given to the DictReader
+    reader = csv.DictReader((line.replace('\0', '') for line in file_stream), fieldnames=None, restkey=SDC_EXTRA_COLUMN, delimiter=options.get('delimiter', ','))
+
+    headers = set(reader.fieldnames)
+    if options.get('key_properties'):
+        key_properties = set(options['key_properties'])
+        if not key_properties.issubset(headers):
+            raise Exception('CSV file missing required headers: {}'
+                            .format(key_properties - headers))
+
+    if options.get('date_overrides'):
+        date_overrides = set(options['date_overrides'])
+        if not date_overrides.issubset(headers):
+            raise Exception('CSV file missing date_overrides headers: {}'
+                            .format(date_overrides - headers))
+    return reader

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -12,10 +12,10 @@ import boto3
 
 from typing import Dict, Generator, Optional, Iterator
 from botocore.exceptions import ClientError
-from singer_encodings.csv import get_row_iterator, SDC_EXTRA_COLUMN  # pylint:disable=no-name-in-module
+from singer_encodings.csv import SDC_EXTRA_COLUMN  # pylint:disable=no-name-in-module
 from singer import get_logger, utils
 
-from tap_s3_csv import conversion
+from tap_s3_csv import conversion, row_iterator
 
 LOGGER = get_logger('tap_s3_csv')
 
@@ -136,7 +136,7 @@ def sample_file(config: Dict, table_spec: Dict, s3_path: str, sample_rate: int) 
     """
     file_handle = get_file_handle(config, s3_path)
     # _raw_stream seems like the wrong way to access this..
-    iterator = get_row_iterator(file_handle._raw_stream, table_spec)  # pylint:disable=protected-access
+    iterator = row_iterator.get_row_iterator(file_handle._raw_stream, table_spec)  # pylint:disable=protected-access
 
     current_row = 0
 

--- a/tap_s3_csv/sync.py
+++ b/tap_s3_csv/sync.py
@@ -7,9 +7,8 @@ import csv
 from typing import Dict
 
 from singer import metadata, Transformer, utils, get_bookmark, write_bookmark, write_state, write_record, get_logger
-from singer_encodings.csv import get_row_iterator # pylint:disable=no-name-in-module
 
-from tap_s3_csv import s3
+from tap_s3_csv import s3, row_iterator
 
 LOGGER = get_logger('tap_s3_csv')
 
@@ -74,7 +73,7 @@ def sync_table_file(config: Dict, s3_path: str, table_spec: Dict, stream: Dict) 
     # need to be fixed. The other consequence of this could be larger
     # memory consumption but that's acceptable as well.
     csv.field_size_limit(sys.maxsize)
-    iterator = get_row_iterator(s3_file_handle._raw_stream, table_spec)  # pylint:disable=protected-access
+    iterator = row_iterator.get_row_iterator(s3_file_handle._raw_stream, table_spec)  # pylint:disable=protected-access
 
     records_synced = 0
 


### PR DESCRIPTION
## Problem

tap-s3-csv does only support utf-8. This PR provides an encoding property in the table structure to specify a different encoding.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions