### PR TITLE
[AP-1550] fix for filter out glacier object

### DIFF
--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -295,12 +295,12 @@ def list_files_in_bucket(bucket: str, search_prefix: str = None, aws_endpoint_ur
         args['Prefix'] = search_prefix
 
     paginator = s3_client.get_paginator('list_objects_v2')
-    pages = 0
-    for page in paginator.paginate(**args):
-        pages += 1
-        LOGGER.debug("On page %s", pages)
-        s3_object_count += len(page.get('Contents', []))
-        yield from page.get('Contents', [])
+    page_iterator = paginator.paginate(**args)
+    filtered_s3_objects = page_iterator.search("Contents[?StorageClass=='STANDARD']")
+
+    for s3_obj in filtered_s3_objects:
+        s3_object_count += 1
+        yield s3_obj
 
     if s3_object_count > 0:
         LOGGER.info("Found %s files.", s3_object_count)


### PR DESCRIPTION
## Problem

The post-mortem tap repeatedly fails because we try to download objects which have been moved to Glacier Storage.

## Proposed changes

filter out Objects which are stored with Glacier.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions